### PR TITLE
go: Set module name to foxygo.at/jsonnext

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/foxygoat/jsonnext
+module foxygo.at/jsonnext
 
 go 1.13
 


### PR DESCRIPTION
This was meant to be done in pr #1, but I forgot. Fix it now so the
module can be imported via its vanity name.